### PR TITLE
歌词滚动时不显示原状态栏

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,14 +9,14 @@ android {
 
         applicationId "statusbar.finder"
         minSdkVersion 26
-        targetSdkVersion 34
+        targetSdk 35
         versionCode 8
         versionName "1.0.8"
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_20
-        targetCompatibility JavaVersion.VERSION_20
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
     }
     packagingOptions {
         resources {

--- a/app/src/main/java/statusbar/finder/MusicListenerService.java
+++ b/app/src/main/java/statusbar/finder/MusicListenerService.java
@@ -347,7 +347,7 @@ public class MusicListenerService extends NotificationListenerService {
             }
             LyricsChanged.Data data = new LyricsChanged.Data(sentence.content.trim(), translatedSentence != null ? translatedSentence.content.trim() : null, delay);
             LyricsChanged.getInstance().notifyLyrics(data);
-            mLyricNotification = buildLrcNotification(data);
+            // mLyricNotification = buildLrcNotification(data);
             mNotificationManager.notify(NOTIFICATION_ID_LRC, mLyricNotification);
             // EventTools.INSTANCE.sendLyric(getApplicationContext(), curLyric, true, drawBase64, false, "", getPackageName(), delay);
             Log.d("updateLyric: ", String.format("Lyric: %s , delay: %d", curLyric, delay));


### PR DESCRIPTION
对应issues
https://github.com/VictorModi/Lyrics-Getter-Ext/issues/2

首次出现该问题的commit
https://github.com/VictorModi/Lyrics-Getter-Ext/commit/12bdc90c056f2bba453f7b40e16f5e3cb6f625c1

不知道是否会对其他功能造成影响




顺便,
由于编译的时候出现了
Inconsistent JVM-target compatibility detected for tasks 'compileDebugJavaWithJavac' (20) and 'compileDebugKotlin' (21). 所以更改java版本到21